### PR TITLE
Update to Crystal 0.26.0

### DIFF
--- a/examples/client.cr
+++ b/examples/client.cr
@@ -14,10 +14,9 @@ TCPSocket.open("localhost", 5555) do |socket|
   end
   SSL::Socket.new_client(socket, ssl_ctx) do |client|
     client.write("hello world".to_slice)
-    buf :: UInt8[512]
+    buf = uninitialized UInt8[512]
     slice = buf.to_slice
     len = client.read(slice)
-    puts "From server: #{String.new slice[0,len]}"
+    puts "From server: #{String.new slice[0, len]}"
   end
 end
-

--- a/examples/server.cr
+++ b/examples/server.cr
@@ -3,7 +3,7 @@ require "../src/openssl"
 
 include OpenSSL
 
-tcp_server = TCPServer.new( 5555 )
+tcp_server = TCPServer.new(5555)
 
 ssl_ctx = SSL::Context.new(SSL::Method::SSLv23)
 
@@ -13,7 +13,7 @@ ssl_ctx.private_key_file = "my_key.pem"
 loop do
   client = tcp_server.accept
   SSL::Socket.new_server(client, ssl_ctx) do |client|
-    buf :: UInt8[512]
+    buf = uninitialized UInt8[512]
     loop do
       len = client.read(buf.to_slice)
       if len > 0
@@ -24,4 +24,3 @@ loop do
     end
   end
 end
-

--- a/spec/dsa_spec.cr
+++ b/spec/dsa_spec.cr
@@ -18,7 +18,7 @@ describe OpenSSL::PKey::DSA do
 
   it "should be able to load DSA from pem" do
     dsa = OpenSSL::PKey::DSA.generate(1024)
-    pem = MemoryIO.new
+    pem = IO::Memory.new
     dsa.to_pem(pem)
 
     pem.rewind

--- a/spec/rsa_spec.cr
+++ b/spec/rsa_spec.cr
@@ -35,7 +35,7 @@ describe OpenSSL::PKey::RSA do
 
   it "should be able to load RSA from pem" do
     rsa = OpenSSL::PKey::RSA.generate(1024)
-    pem = MemoryIO.new
+    pem = IO::Memory.new
     rsa.to_pem(pem)
 
     pem.rewind
@@ -54,4 +54,3 @@ describe OpenSSL::PKey::RSA do
     rsa.verify(digest, signature[0, 10], data).should be_false
   end
 end
-

--- a/spec/x509_spec.cr
+++ b/spec/x509_spec.cr
@@ -25,7 +25,7 @@ EOC
 
 describe Certificate do
   it "should be able to load certificate from PEM" do
-    certificate = Certificate.from_pem(MemoryIO.new(CERT))
+    certificate = Certificate.from_pem(IO::Memory.new(CERT))
     certificate.subject_name.name.should eq("CN=MyName")
     certificate.fingerprint_hex.should eq("454ed8ec8b5a21f785de57edb5318381bccc98cd")
   end
@@ -43,7 +43,7 @@ describe Generator do
     certificate.subject_name.name.should eq("CN=MyName")
     certificate.verify(pkey).should be_true
 
-    loaded_certificate = Certificate.from_pem(MemoryIO.new(certificate.to_pem))
+    loaded_certificate = Certificate.from_pem(IO::Memory.new(certificate.to_pem))
     loaded_certificate.subject_name.name.should eq("CN=MyName")
     loaded_certificate.fingerprint_hex.should eq(certificate.fingerprint_hex)
   end

--- a/src/bio/bio.cr
+++ b/src/bio/bio.cr
@@ -6,18 +6,18 @@ struct OpenSSL::BIO
     crystal_bio = LibCrypto::BioMethod.new
     crystal_bio.name = "Crystal BIO".cstr
 
-    crystal_bio.bwrite = -> (bio : LibCrypto::BIO, data : UInt8*, len : Int32) do
+    crystal_bio.bwrite = ->(bio : LibCrypto::BIO, data : UInt8*, len : Int32) do
       io = Box(IO).unbox(bio.value.ptr)
       io.write Slice.new(data, len)
       len
     end
 
-    crystal_bio.bread = -> (bio : LibCrypto::BIO, buffer : UInt8*, len : Int32) do
+    crystal_bio.bread = ->(bio : LibCrypto::BIO, buffer : UInt8*, len : Int32) do
       io = Box(IO).unbox(bio.value.ptr)
       io.read(Slice.new(buffer, len)).to_i
     end
 
-    crystal_bio.ctrl = -> (bio : LibCrypto::BIO, cmd : Int32, num : Int64, ptr : Void*) do
+    crystal_bio.ctrl = ->(bio : LibCrypto::BIO, cmd : Int32, num : Int64, ptr : Void*) do
       io = Box(IO).unbox(bio.value.ptr)
 
       case cmd
@@ -31,13 +31,13 @@ struct OpenSSL::BIO
       end
     end
 
-    crystal_bio.create = -> (bio : LibCrypto::BIO) do
+    crystal_bio.create = ->(bio : LibCrypto::BIO) do
       bio.value.shutdown = 1
       bio.value.init = 1
       bio.value.num = -1
     end
 
-    crystal_bio.destroy = -> (bio : LibCrypto::BIO) { bio.value.ptr = Pointer(Void).null; 1 }
+    crystal_bio.destroy = ->(bio : LibCrypto::BIO) { bio.value.ptr = Pointer(Void).null; 1 }
 
     crystal_bio
   end

--- a/src/bio/mem_bio.cr
+++ b/src/bio/mem_bio.cr
@@ -1,41 +1,42 @@
 require "../openssl"
 
-struct OpenSSL::MemBIO
-  include IO
+module OpenSSL
+  class MemBIO
+    class BIOError < OpenSSLError
+    end
 
-  class BIOError < OpenSSLError; end
+    def initialize(@bio : LibCrypto::BIO)
+      raise BIOError.new "Invalid handle" unless @bio
+    end
 
-  def initialize(@bio : LibCrypto::BIO)
-    raise BIOError.new "Invalid handle" unless @bio
-  end
+    def initialize
+      initialize LibCrypto.bio_new(LibCrypto.bio_s_mem)
+    end
 
-  def initialize
-    initialize LibCrypto.bio_new(LibCrypto.bio_s_mem())
-  end
+    def read(data : Slice(UInt8))
+      LibCrypto.bio_read(self, data, data.size)
+    end
 
-  def read(data : Slice(UInt8))
-    LibCrypto.bio_read(self, data, data.size)
-  end
+    def write(data : Slice(UInt8))
+      LibCrypto.bio_write(self, data, data.size)
+    end
 
-  def write(data : Slice(UInt8))
-    LibCrypto.bio_write(self, data, data.size)
-  end
+    def reset
+      LibCrypto.bio_ctrl(self, LibCrypto::BIO_CTRL_RESET, 0_i64, nil)
+    end
 
-  def reset
-    LibCrypto.bio_ctrl(self, LibCrypto::BIO_CTRL_RESET, 0_i64, nil)
-  end
+    def finalize
+      LibCrypto.bio_free_all(self)
+    end
 
-  def finalize
-    LibCrypto.bio_free_all(self)
-  end
+    def to_string
+      buf = IO::Memory.new
+      IO.copy(self, buf)
+      buf.to_s
+    end
 
-  def to_string
-    buf = MemoryIO.new
-    IO.copy(self, buf)
-    buf.to_s
-  end
-
-  def to_unsafe
-    @bio
+    def to_unsafe
+      @bio
+    end
   end
 end

--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -21,7 +21,7 @@ module OpenSSL
 
     getter name
 
-    def initialize(@name, @ctx : LibCrypto::EVP_MD_CTX)
+    def initialize(@name : String, @ctx : LibCrypto::EVP_MD_CTX)
       raise DigestError.new("Invalid EVP_MD_CTX") unless @ctx
     end
 
@@ -35,7 +35,7 @@ module OpenSSL
       unless md
         raise "Unsupported digest algoritm: #{name}"
       end
-      ctx = LibCrypto.evp_md_ctx_create()
+      ctx = LibCrypto.evp_md_ctx_new
       unless ctx
         raise OpenSSL::Digest::DigestError.new "Digest initialization failed."
       end
@@ -50,13 +50,13 @@ module OpenSSL
     end
 
     def finalize
-      LibCrypto.evp_md_ctx_destroy(self)
+      LibCrypto.evp_md_ctx_free(self)
     end
 
     def clone
-      ctx = LibCrypto.evp_md_ctx_create()
+      ctx = LibCrypto.evp_md_ctx_new
       if LibCrypto.evp_md_ctx_copy(ctx, @ctx) == 0
-        LibCrypto.evp_md_ctx_destroy(ctx)
+        LibCrypto.evp_md_ctx_free(ctx)
         raise DigestError.new("Unable to clone digest")
       end
       Digest.new(@name, ctx)

--- a/src/digest/hmac.cr
+++ b/src/digest/hmac.cr
@@ -17,7 +17,7 @@ class OpenSSL::HMAC
 
   def self.new(key, digest)
     new.tap do |hmac|
-      LibCrypto.hmac_init_ex(hmac, key.to_unsafe as Pointer(Void), key.bytesize, digest.to_unsafe_md, nil)
+      LibCrypto.hmac_init_ex(hmac, key.to_unsafe.as(Pointer(Void)), key.bytesize, digest.to_unsafe_md, nil)
     end
   end
 

--- a/src/lib/lib_crypto.cr
+++ b/src/lib/lib_crypto.cr
@@ -1,35 +1,36 @@
 @[Link("crypto")]
 lib LibCrypto
   # from headers
-  PKCS5_SALT_LEN = 8
+  PKCS5_SALT_LEN     =  8
   EVP_MAX_KEY_LENGTH = 32
-  EVP_MAX_IV_LENGTH = 16
+  EVP_MAX_IV_LENGTH  = 16
 
-  fun err_error_string = ERR_error_string(e: UInt64, buf: UInt8*) : UInt8*
-  fun get_error = ERR_get_error() : UInt64
+  fun err_error_string = ERR_error_string(e : UInt64, buf : UInt8*) : UInt8*
+  fun get_error = ERR_get_error : UInt64
   fun cleanse = OPENSSL_cleanse(ptr : UInt8*, len : UInt32)
 
   alias EVP_MD = Void*
 
   struct EVP_MD_CTX_Struct
-    digest: EVP_MD
-    engine: Void*
-    flags: UInt32
-    pctx: Void*
-    update_fun: Void*
+    digest : EVP_MD
+    engine : Void*
+    flags : UInt32
+    pctx : Void*
+    update_fun : Void*
   end
+
   alias EVP_MD_CTX = EVP_MD_CTX_Struct*
 
-  fun evp_md_ctx_create = EVP_MD_CTX_create() : EVP_MD_CTX
-  fun evp_get_digestbyname = EVP_get_digestbyname(name: UInt8*): EVP_MD
-  fun evp_digestinit_ex = EVP_DigestInit_ex(ctx: EVP_MD_CTX, type: EVP_MD, engine: Void*) : Int32
-  fun evp_md_ctx_destroy = EVP_MD_CTX_destroy(ctx: EVP_MD_CTX)
-  fun evp_md_ctx_md = EVP_MD_CTX_md(ctx: EVP_MD_CTX) : EVP_MD
-  fun evp_digestupdate = EVP_DigestUpdate(ctx: EVP_MD_CTX, data: UInt8*, count: LibC::SizeT) : Int32
-  fun evp_md_size = EVP_MD_size(md: EVP_MD) : Int32
-  fun evp_digestfinal_ex = EVP_DigestFinal_ex(ctx: EVP_MD_CTX, md: UInt8*, size: UInt32*) : Int32
-  fun evp_md_block_size = EVP_MD_block_size(md: EVP_MD) : Int32
-  fun evp_md_ctx_copy = EVP_MD_CTX_copy(dst: EVP_MD_CTX, src: EVP_MD_CTX) : Int32
+  fun evp_md_ctx_new = EVP_MD_CTX_new : EVP_MD_CTX
+  fun evp_get_digestbyname = EVP_get_digestbyname(name : UInt8*) : EVP_MD
+  fun evp_digestinit_ex = EVP_DigestInit_ex(ctx : EVP_MD_CTX, type : EVP_MD, engine : Void*) : Int32
+  fun evp_md_ctx_free = EVP_MD_CTX_free(ctx : EVP_MD_CTX)
+  fun evp_md_ctx_md = EVP_MD_CTX_md(ctx : EVP_MD_CTX) : EVP_MD
+  fun evp_digestupdate = EVP_DigestUpdate(ctx : EVP_MD_CTX, data : UInt8*, count : LibC::SizeT) : Int32
+  fun evp_md_size = EVP_MD_size(md : EVP_MD) : Int32
+  fun evp_digestfinal_ex = EVP_DigestFinal_ex(ctx : EVP_MD_CTX, md : UInt8*, size : UInt32*) : Int32
+  fun evp_md_block_size = EVP_MD_block_size(md : EVP_MD) : Int32
+  fun evp_md_ctx_copy = EVP_MD_CTX_copy(dst : EVP_MD_CTX, src : EVP_MD_CTX) : Int32
 
   fun evp_bytestokey = EVP_BytesToKey(ctype : EVP_CIPHER, md : EVP_MD, salt : UInt8*, pass : UInt8*, passlen : Int32, iter : Int32, key : UInt8*, iv : UInt8*) : Int32
 
@@ -44,7 +45,7 @@ lib LibCrypto
   fun evp_cipher_key_length = EVP_CIPHER_key_length(cipher : EVP_CIPHER) : Int32
   fun evp_cipher_iv_length = EVP_CIPHER_iv_length(cipher : EVP_CIPHER) : Int32
 
-  fun evp_cipher_ctx_new = EVP_CIPHER_CTX_new() : EVP_CIPHER_CTX
+  fun evp_cipher_ctx_new = EVP_CIPHER_CTX_new : EVP_CIPHER_CTX
   fun evp_cipher_ctx_free = EVP_CIPHER_CTX_free(ctx : EVP_CIPHER_CTX)
   fun evp_cipherinit_ex = EVP_CipherInit_ex(ctx : EVP_CIPHER_CTX, type : EVP_CIPHER, engine : Void*, key : UInt8*, iv : UInt8*, enc : Int32) : Int32
   fun evp_cipherupdate = EVP_CipherUpdate(ctx : EVP_CIPHER_CTX, out_buf : UInt8*, outl : Int32*, in_buf : UInt8*, inl : Int32) : Int32
@@ -54,35 +55,35 @@ lib LibCrypto
 
   alias EVP_PKEY = Void*
 
-  fun evp_pkey_size = EVP_PKEY_size(pkey: EVP_PKEY) : Int32
-  fun evp_signfinal = EVP_SignFinal(ctx: EVP_MD_CTX, sigret: UInt8*, siglen: UInt32*, pkey: EVP_PKEY) : Int32
-  fun evp_verifyfinal = EVP_VerifyFinal(ctx: EVP_MD_CTX, sigbuf: UInt8*, siglen: UInt32, pkey: EVP_PKEY) : Int32
-  fun evp_pkey_new = EVP_PKEY_new() : EVP_PKEY
-  fun evp_pkey_free = EVP_PKEY_free(pkey: EVP_PKEY)
+  fun evp_pkey_size = EVP_PKEY_size(pkey : EVP_PKEY) : Int32
+  fun evp_signfinal = EVP_SignFinal(ctx : EVP_MD_CTX, sigret : UInt8*, siglen : UInt32*, pkey : EVP_PKEY) : Int32
+  fun evp_verifyfinal = EVP_VerifyFinal(ctx : EVP_MD_CTX, sigbuf : UInt8*, siglen : UInt32, pkey : EVP_PKEY) : Int32
+  fun evp_pkey_new = EVP_PKEY_new : EVP_PKEY
+  fun evp_pkey_free = EVP_PKEY_free(pkey : EVP_PKEY)
 
-  NID_undef = 0
-  NID_rsaEncryption = 6
-  NID_dsa = 116
+  NID_undef         =   0
+  NID_rsaEncryption =   6
+  NID_dsa           = 116
 
-  fun evp_pkey_assign = EVP_PKEY_assign(pkey: EVP_PKEY, type: Int32, key: Void*) : Int32
+  fun evp_pkey_assign = EVP_PKEY_assign(pkey : EVP_PKEY, type : Int32, key : Void*) : Int32
 
   struct HMAC_CTX_Struct
-    md: EVP_MD
-    md_ctx: EVP_MD_CTX_Struct
-    i_ctx: EVP_MD_CTX_Struct
-    o_ctx: EVP_MD_CTX_Struct
-    key_length: UInt32
-    key: UInt8[128]
+    md : EVP_MD
+    md_ctx : EVP_MD_CTX_Struct
+    i_ctx : EVP_MD_CTX_Struct
+    o_ctx : EVP_MD_CTX_Struct
+    key_length : UInt32
+    key : UInt8[128]
   end
 
   alias HMAC_CTX = HMAC_CTX_Struct*
 
-  fun hmac_ctx_init = HMAC_CTX_init(ctx: HMAC_CTX)
-  fun hmac_ctx_cleanup = HMAC_CTX_cleanup(ctx: HMAC_CTX)
-  fun hmac_init_ex = HMAC_Init_ex(ctx: HMAC_CTX, key: Void*, len: Int32, md: EVP_MD, engine: Void*) : Int32
-  fun hmac_update = HMAC_Update(ctx: HMAC_CTX, data: UInt8*, len: LibC::SizeT) : Int32
-  fun hmac_final = HMAC_Final(ctx: HMAC_CTX, md: UInt8*, len: UInt32*) : Int32
-  fun hmac_ctx_copy = HMAC_CTX_copy(dst: HMAC_CTX, src: HMAC_CTX) : Int32
+  fun hmac_ctx_init = HMAC_CTX_new(ctx : HMAC_CTX)
+  fun hmac_ctx_cleanup = HMAC_CTX_free(ctx : HMAC_CTX)
+  fun hmac_init_ex = HMAC_Init_ex(ctx : HMAC_CTX, key : Void*, len : Int32, md : EVP_MD, engine : Void*) : Int32
+  fun hmac_update = HMAC_Update(ctx : HMAC_CTX, data : UInt8*, len : LibC::SizeT) : Int32
+  fun hmac_final = HMAC_Final(ctx : HMAC_CTX, md : UInt8*, len : UInt32*) : Int32
+  fun hmac_ctx_copy = HMAC_CTX_copy(dst : HMAC_CTX, src : HMAC_CTX) : Int32
 
   struct BioStruct
     method : Void*
@@ -103,8 +104,8 @@ lib LibCrypto
 
   alias BIO = BioStruct*
 
-  CTRL_PUSH = 6
-  CTRL_POP = 7
+  CTRL_PUSH  =  6
+  CTRL_POP   =  7
   CTRL_FLUSH = 11
 
   struct BioMethod
@@ -122,43 +123,43 @@ lib LibCrypto
 
   alias BIO_METHOD = BioMethod*
 
-  fun bio_s_mem = BIO_s_mem() : BIO_METHOD
-  fun bio_new = BIO_new(type: BIO_METHOD) : BIO
-  fun bio_free_all = BIO_free_all(bio: BIO)
-  fun bio_read = BIO_read(bio: BIO, data: UInt8*, len: Int32) : Int32
-  fun bio_write = BIO_write(bio: BIO, data: UInt8*, len: Int32) : Int32
+  fun bio_s_mem = BIO_s_mem : BIO_METHOD
+  fun bio_new = BIO_new(type : BIO_METHOD) : BIO
+  fun bio_free_all = BIO_free_all(bio : BIO)
+  fun bio_read = BIO_read(bio : BIO, data : UInt8*, len : Int32) : Int32
+  fun bio_write = BIO_write(bio : BIO, data : UInt8*, len : Int32) : Int32
 
   BIO_CTRL_RESET = 1
-  fun bio_ctrl = BIO_ctrl(bio: BIO, cmd: Int32, larg: Int64, parg: Void*) : Int64
+  fun bio_ctrl = BIO_ctrl(bio : BIO, cmd : Int32, larg : Int64, parg : Void*) : Int64
 
   alias ASN1_OBJECT = Void*
   alias ASN1_INTEGER = Void*
   alias ASN1_TIME = Void*
 
-  fun obj_txt2obj = OBJ_txt2obj(s: UInt8*, no_name: Int32) : ASN1_OBJECT
-  fun obj_nid2sn = OBJ_nid2sn(n: Int32) : UInt8*
-  fun obj_obj2nid = OBJ_obj2nid(obj: ASN1_OBJECT) : Int32
-  fun asn1_object_free = ASN1_OBJECT_free(obj: ASN1_OBJECT)
-  fun asn1_dup = ASN1_dup(i2d: Void*, d2i_of_void: Void*, x: Void*) : Void*
-  fun i2a_asn1_object = i2a_ASN1_OBJECT(bio: BIO, asn: ASN1_OBJECT) : Int32
-  fun obj_txt2obj = OBJ_txt2obj(s: UInt8*, no_name: Int32) : ASN1_OBJECT
-  fun asn1_object_size = ASN1_object_size(constructed: Int32, length: Int32, tag: Int32) : Int32
-  fun asn1_put_object = ASN1_put_object(pp: UInt8**, constructed: Int32, length: Int32, tag: Int32, xclass: Int32)
-  fun asn1_integer_set = ASN1_INTEGER_set(a: ASN1_INTEGER, v: Int64) : Int32
-  fun asn1_time_free = ASN1_TIME_free(t: ASN1_TIME)
-  fun x509_gmtime_adj = X509_gmtime_adj(t: ASN1_TIME, adj: Int64) : ASN1_TIME
+  fun obj_txt2obj = OBJ_txt2obj(s : UInt8*, no_name : Int32) : ASN1_OBJECT
+  fun obj_nid2sn = OBJ_nid2sn(n : Int32) : UInt8*
+  fun obj_obj2nid = OBJ_obj2nid(obj : ASN1_OBJECT) : Int32
+  fun asn1_object_free = ASN1_OBJECT_free(obj : ASN1_OBJECT)
+  fun asn1_dup = ASN1_dup(i2d : Void*, d2i_of_void : Void*, x : Void*) : Void*
+  fun i2a_asn1_object = i2a_ASN1_OBJECT(bio : BIO, asn : ASN1_OBJECT) : Int32
+  fun obj_txt2obj = OBJ_txt2obj(s : UInt8*, no_name : Int32) : ASN1_OBJECT
+  fun asn1_object_size = ASN1_object_size(constructed : Int32, length : Int32, tag : Int32) : Int32
+  fun asn1_put_object = ASN1_put_object(pp : UInt8**, constructed : Int32, length : Int32, tag : Int32, xclass : Int32)
+  fun asn1_integer_set = ASN1_INTEGER_set(a : ASN1_INTEGER, v : Int64) : Int32
+  fun asn1_time_free = ASN1_TIME_free(t : ASN1_TIME)
+  fun x509_gmtime_adj = X509_gmtime_adj(t : ASN1_TIME, adj : Int64) : ASN1_TIME
 
   alias PasswordCallback = (UInt8*, Int32, Int32, Void*) -> Int32
 
   alias RSA = Void*
 
-  fun rsa_generate_key = RSA_generate_key(bits: Int32, e: UInt32, cb: (Int32, Int32, Void*) ->, ud: Void*) : RSA
-  fun rsapublickey_dup = RSAPublicKey_dup(rsa: RSA) : RSA
-  fun evp_pkey_get1_rsa = EVP_PKEY_get1_RSA(pk: EVP_PKEY) : RSA
-  fun rsa_print = RSA_print(bio: BIO, rsa: RSA, off: Int32) : Int32
-  fun i2d_rsaprivatekey = i2d_RSAPrivateKey(rsa: RSA, buf: UInt8**) : Int32
-  fun i2d_rsa_pubkey = i2d_RSA_PUBKEY(rsa: RSA, buf: UInt8**) : Int32
-  fun rsa_size = RSA_size(rsa: RSA) : Int32
+  fun rsa_generate_key = RSA_generate_key(bits : Int32, e : UInt32, cb : (Int32, Int32, Void*) ->, ud : Void*) : RSA
+  fun rsapublickey_dup = RSAPublicKey_dup(rsa : RSA) : RSA
+  fun evp_pkey_get1_rsa = EVP_PKEY_get1_RSA(pk : EVP_PKEY) : RSA
+  fun rsa_print = RSA_print(bio : BIO, rsa : RSA, off : Int32) : Int32
+  fun i2d_rsaprivatekey = i2d_RSAPrivateKey(rsa : RSA, buf : UInt8**) : Int32
+  fun i2d_rsa_pubkey = i2d_RSA_PUBKEY(rsa : RSA, buf : UInt8**) : Int32
+  fun rsa_size = RSA_size(rsa : RSA) : Int32
 
   enum Padding
     PKCS1_PADDING      = 1
@@ -169,94 +170,95 @@ lib LibCrypto
     PKCS1_PSS_PADDING  = 6
   end
 
-  fun rsa_public_encrypt = RSA_public_encrypt(flen: Int32, from: UInt8*, to: UInt8*, rsa: RSA, p: Padding) : Int32
-  fun rsa_public_decrypt = RSA_public_decrypt(flen: Int32, from: UInt8*, to: UInt8*, rsa: RSA, p: Padding) : Int32
-  fun rsa_private_encrypt = RSA_private_encrypt(flen: Int32, from: UInt8*, to: UInt8*, rsa: RSA, p: Padding) : Int32
-  fun rsa_private_decrypt = RSA_private_decrypt(flen: Int32, from: UInt8*, to: UInt8*, rsa: RSA, p: Padding) : Int32
+  fun rsa_public_encrypt = RSA_public_encrypt(flen : Int32, from : UInt8*, to : UInt8*, rsa : RSA, p : Padding) : Int32
+  fun rsa_public_decrypt = RSA_public_decrypt(flen : Int32, from : UInt8*, to : UInt8*, rsa : RSA, p : Padding) : Int32
+  fun rsa_private_encrypt = RSA_private_encrypt(flen : Int32, from : UInt8*, to : UInt8*, rsa : RSA, p : Padding) : Int32
+  fun rsa_private_decrypt = RSA_private_decrypt(flen : Int32, from : UInt8*, to : UInt8*, rsa : RSA, p : Padding) : Int32
 
-  fun pem_read_bio_privatekey = PEM_read_bio_PrivateKey(bio: BIO, pk: EVP_PKEY*, cb: PasswordCallback, user_data: Void*) : EVP_PKEY
-  fun pem_write_bio_rsaprivatekey = PEM_write_bio_RSAPrivateKey(bio: BIO, rsa: RSA, enc: EVP_CIPHER,
-                                                                kstr: UInt8*, klen: Int32, cb: PasswordCallback, user_data: Void*) : Int32
-  fun pem_write_bio_rsa_pubkey = PEM_write_bio_RSA_PUBKEY(bio: BIO, rsa: RSA)
+  fun pem_read_bio_privatekey = PEM_read_bio_PrivateKey(bio : BIO, pk : EVP_PKEY*, cb : PasswordCallback, user_data : Void*) : EVP_PKEY
+  fun pem_write_bio_rsaprivatekey = PEM_write_bio_RSAPrivateKey(bio : BIO, rsa : RSA, enc : EVP_CIPHER,
+                                                                kstr : UInt8*, klen : Int32, cb : PasswordCallback, user_data : Void*) : Int32
+  fun pem_write_bio_rsa_pubkey = PEM_write_bio_RSA_PUBKEY(bio : BIO, rsa : RSA)
 
-  fun rand_bytes = RAND_bytes(buf: UInt8*, num: Int32) : Int32
+  fun rand_bytes = RAND_bytes(buf : UInt8*, num : Int32) : Int32
 
   alias DSA = Void*
 
-  fun dsa_generate_parameters = DSA_generate_parameters(bit: Int32, seed: UInt8*, seed_len: Int32, counter_ret: Int32*,
-                                                        h_ret: UInt64*, cb: Void*, user_data: Void*) : DSA
-  fun dsa_generate_key = DSA_generate_key(dsa: DSA): Int32
-  fun dsa_free = DSA_free(dsa: DSA)
-  fun pem_read_bio_dsaprivatekey = PEM_read_bio_DSAPrivateKey(bio: BIO, dsa: DSA*, cb: PasswordCallback, user_data: Void*) : DSA
-  fun d2i_dsaprivatekey_bio = d2i_DSAPrivateKey_bio(bio: BIO, dsa: DSA*) : DSA
-  fun d2i_dsa_pubkey_bio = d2i_DSA_PUBKEY_bio(bio: BIO, dsa: DSA*) : DSA
+  fun dsa_generate_parameters = DSA_generate_parameters(bit : Int32, seed : UInt8*, seed_len : Int32, counter_ret : Int32*,
+                                                        h_ret : UInt64*, cb : Void*, user_data : Void*) : DSA
+  fun dsa_generate_key = DSA_generate_key(dsa : DSA) : Int32
+  fun dsa_free = DSA_free(dsa : DSA)
+  fun pem_read_bio_dsaprivatekey = PEM_read_bio_DSAPrivateKey(bio : BIO, dsa : DSA*, cb : PasswordCallback, user_data : Void*) : DSA
+  fun d2i_dsaprivatekey_bio = d2i_DSAPrivateKey_bio(bio : BIO, dsa : DSA*) : DSA
+  fun d2i_dsa_pubkey_bio = d2i_DSA_PUBKEY_bio(bio : BIO, dsa : DSA*) : DSA
 
-  fun pem_write_bio_dsaprivatekey = PEM_write_bio_DSAPrivateKey(bio: BIO, dsa: DSA, c: EVP_CIPHER, kstr: UInt8*, klen: Int32,
-                                                                cb: PasswordCallback, user_data: Void*) : Int32
-  fun pem_write_bio_dsa_pubkey = PEM_write_bio_DSA_PUBKEY(bio: BIO, dsa: DSA) : Int32
-  fun evp_pkey_get1_dsa = EVP_PKEY_get1_DSA(pkey: EVP_PKEY) : DSA
-  fun i2d_dsaprivatekey = i2d_DSAPrivateKey(dsa: DSA, pp: UInt8**) : Int32
-  fun i2d_dsa_pubkey = i2d_DSA_PUBKEY(dsa: DSA, pp: UInt8**) : Int32
-  fun dsa_size = DSA_size(dsa: DSA) : Int32
-  fun dsa_sign = DSA_sign(type: Int32, dgst: UInt8*, dlen: Int32, sig: UInt8*, siglen: Int32*, dsa: DSA) : Int32
-  fun dsa_verify = DSA_verify(type: Int32, dgst: UInt8*, dlen: Int32, sig: UInt8*, siglen: Int32, dsa: DSA) : Int32
-  fun i2d_dsapublickey = i2d_DSAPublicKey(dsa: DSA, pp: UInt8**) : Int32
-  fun d2i_dsapublickey = d2i_DSAPublicKey(dsa: DSA*, pp: UInt8**, length: Int64) : Int32
+  fun pem_write_bio_dsaprivatekey = PEM_write_bio_DSAPrivateKey(bio : BIO, dsa : DSA, c : EVP_CIPHER, kstr : UInt8*, klen : Int32,
+                                                                cb : PasswordCallback, user_data : Void*) : Int32
+  fun pem_write_bio_dsa_pubkey = PEM_write_bio_DSA_PUBKEY(bio : BIO, dsa : DSA) : Int32
+  fun evp_pkey_get1_dsa = EVP_PKEY_get1_DSA(pkey : EVP_PKEY) : DSA
+  fun i2d_dsaprivatekey = i2d_DSAPrivateKey(dsa : DSA, pp : UInt8**) : Int32
+  fun i2d_dsa_pubkey = i2d_DSA_PUBKEY(dsa : DSA, pp : UInt8**) : Int32
+  fun dsa_size = DSA_size(dsa : DSA) : Int32
+  fun dsa_sign = DSA_sign(type : Int32, dgst : UInt8*, dlen : Int32, sig : UInt8*, siglen : Int32*, dsa : DSA) : Int32
+  fun dsa_verify = DSA_verify(type : Int32, dgst : UInt8*, dlen : Int32, sig : UInt8*, siglen : Int32, dsa : DSA) : Int32
+  fun i2d_dsapublickey = i2d_DSAPublicKey(dsa : DSA, pp : UInt8**) : Int32
+  fun d2i_dsapublickey = d2i_DSAPublicKey(dsa : DSA*, pp : UInt8**, length : Int64) : Int32
 
   alias X509_NAME = Void*
 
-  fun x509_name_free = X509_NAME_free(name: X509_NAME)
-  fun x509_name_dup = X509_NAME_dup(name: X509_NAME) : X509_NAME
-  fun x509_name_print_ex = X509_NAME_print_ex(bio: BIO, name: X509_NAME, indent: Int32, flags: UInt64) : Int32
+  fun x509_name_free = X509_NAME_free(name : X509_NAME)
+  fun x509_name_dup = X509_NAME_dup(name : X509_NAME) : X509_NAME
+  fun x509_name_print_ex = X509_NAME_print_ex(bio : BIO, name : X509_NAME, indent : Int32, flags : UInt64) : Int32
 
   alias X509_STORE_CTX = Void*
   alias X509 = Void*
 
-  fun x509_store_ctx_get_error = X509_STORE_CTX_get_error(store: X509_STORE_CTX) : Int32
-  fun x509_store_ctx_get_current_cert = X509_STORE_CTX_get_current_cert(store: X509_STORE_CTX) : X509
+  fun x509_store_ctx_get_error = X509_STORE_CTX_get_error(store : X509_STORE_CTX) : Int32
+  fun x509_store_ctx_get_current_cert = X509_STORE_CTX_get_current_cert(store : X509_STORE_CTX) : X509
 
-  fun x509_new = X509_new() : X509
-  fun x509_free = X509_free(x509: X509)
-  fun pem_read_bio_x509 = PEM_read_bio_X509(bio: BIO, x509: X509*, cb: PasswordCallback, user_data: Void*) : X509
-  fun pem_write_bio_x509 = PEM_write_bio_X509(bio: BIO, x509: X509) : Int32
-  fun x509_get_pubkey = X509_get_pubkey(x509: X509) : EVP_PKEY
-  fun x509_get_subject_name = X509_get_subject_name(x509: X509) : X509_NAME
-  fun x509_digest = X509_digest(x509: X509, type: EVP_MD, md: UInt8*, len: UInt32*) : Int32
-  fun x509_set_version = X509_set_version(x509: X509, version: Int64) : Int32
-  fun x509_get_serialnumber = X509_get_serialNumber(x509: X509) : ASN1_INTEGER
-  fun x509_set_notbefore = X509_set_notBefore(x509: X509, tm: ASN1_TIME) : Int32
-  fun x509_set_notafter = X509_set_notAfter(x509: X509, tm: ASN1_TIME) : Int32
-  fun x509_set_pubkey = X509_set_pubkey(x509: X509, pkey: EVP_PKEY) : Int32
-  fun x509_verify = X509_verify(x509: X509, pkey: EVP_PKEY) : Int32
+  fun x509_new = X509_new : X509
+  fun x509_free = X509_free(x509 : X509)
+  fun pem_read_bio_x509 = PEM_read_bio_X509(bio : BIO, x509 : X509*, cb : PasswordCallback, user_data : Void*) : X509
+  fun pem_write_bio_x509 = PEM_write_bio_X509(bio : BIO, x509 : X509) : Int32
+  fun x509_get_pubkey = X509_get_pubkey(x509 : X509) : EVP_PKEY
+  fun x509_get_subject_name = X509_get_subject_name(x509 : X509) : X509_NAME
+  fun x509_digest = X509_digest(x509 : X509, type : EVP_MD, md : UInt8*, len : UInt32*) : Int32
+  fun x509_set_version = X509_set_version(x509 : X509, version : Int64) : Int32
+  fun x509_get_serialnumber = X509_get_serialNumber(x509 : X509) : ASN1_INTEGER
+  fun x509_set_notbefore = X509_set1_notBefore(x509 : X509, tm : ASN1_TIME) : Int32
+  fun x509_set_notafter = X509_set1_notAfter(x509 : X509, tm : ASN1_TIME) : Int32
+  fun x509_set_pubkey = X509_set_pubkey(x509 : X509, pkey : EVP_PKEY) : Int32
+  fun x509_verify = X509_verify(x509 : X509, pkey : EVP_PKEY) : Int32
 
   MBSTRING_FLAG = 0x1000
   MBSTRING_UTF8 = MBSTRING_FLAG
 
-  fun x509_name_add_entry_by_txt = X509_NAME_add_entry_by_txt(name: X509_NAME, field: UInt8*, type: Int32, bytes: UInt8*, len: Int32,
-                                                              loc: Int32, set: Int32) : Int32
-  fun x509_set_issuer_name = X509_set_issuer_name(x509: X509, name: X509_NAME) : Int32
+  fun x509_name_add_entry_by_txt = X509_NAME_add_entry_by_txt(name : X509_NAME, field : UInt8*, type : Int32, bytes : UInt8*, len : Int32,
+                                                              loc : Int32, set : Int32) : Int32
+  fun x509_set_issuer_name = X509_set_issuer_name(x509 : X509, name : X509_NAME) : Int32
 
   struct X509V3_CTX
-    flags: Int32
-    issuer_cert: Void*
-    subject_cert: Void*
-    subject_req: Void*
-    crl: Void*
-    db_meth: Void*
-    db: Void*
+    flags : Int32
+    issuer_cert : Void*
+    subject_cert : Void*
+    subject_req : Void*
+    crl : Void*
+    db_meth : Void*
+    db : Void*
   end
+
   alias X509_REQ = Void*
   alias X509_CRL = Void*
   alias X509_EXTENSION = Void*
 
-  fun x509v3_set_ctx = X509V3_set_ctx(ctx: X509V3_CTX*, issuer: X509, subj: X509, req: X509_REQ,
-                                      crl: X509_CRL, flags: Int32)
-  fun x509v3_ext_conf_nid = X509V3_EXT_conf_nid(conf: Void*, ctx: X509V3_CTX*, ext_nid: Int32, value: UInt8*): X509_EXTENSION
-  fun x509_add_ext = X509_add_ext(x509: X509, ex: X509_EXTENSION, loc: Int32) : Int32
+  fun x509v3_set_ctx = X509V3_set_ctx(ctx : X509V3_CTX*, issuer : X509, subj : X509, req : X509_REQ,
+                                      crl : X509_CRL, flags : Int32)
+  fun x509v3_ext_conf_nid = X509V3_EXT_conf_nid(conf : Void*, ctx : X509V3_CTX*, ext_nid : Int32, value : UInt8*) : X509_EXTENSION
+  fun x509_add_ext = X509_add_ext(x509 : X509, ex : X509_EXTENSION, loc : Int32) : Int32
 
   NID_ext_key_usage = 126
-  NID_key_usage     = 83
+  NID_key_usage     =  83
 
-  fun x509_extension_free = X509_EXTENSION_free(ex: X509_EXTENSION)
-  fun x509_sign = X509_sign(x509: X509, pkey: EVP_PKEY, md: EVP_MD) : Int32
+  fun x509_extension_free = X509_EXTENSION_free(ex : X509_EXTENSION)
+  fun x509_sign = X509_sign(x509 : X509, pkey : EVP_PKEY, md : EVP_MD) : Int32
 end

--- a/src/lib/lib_ssl.cr
+++ b/src/lib/lib_ssl.cr
@@ -2,85 +2,79 @@ require "./lib_crypto"
 
 @[Link("ssl")]
 lib LibSSL
-
-  fun ssl_library_init = SSL_library_init()
-  fun openssl_add_all_algorithms = OPENSSL_add_all_algorithms_noconf()
-  fun err_load_crypto_strings = ERR_load_crypto_strings()
-  fun ssl_load_error_strings = SSL_load_error_strings()
-
   alias SSL_METHOD = Void*
 
   # fun sslv2_method = SSLv2_method() : SSL_METHOD
-  fun sslv3_method = SSLv3_method() : SSL_METHOD
-  fun sslv23_method = SSLv23_method() : SSL_METHOD
-  fun tlsv1_method = TLSv1_method() : SSL_METHOD
-  fun tlsv1_1_method = TLSv1_1_method() : SSL_METHOD
-  fun tlsv1_2_method = TLSv1_2_method() : SSL_METHOD
-  fun dtlsv1_method = DTLSv1_method() : SSL_METHOD
-  fun dtlsv1_2_method = DTLSv1_2_method() : SSL_METHOD
+  fun sslv3_method = SSLv3_method : SSL_METHOD
+  fun sslv23_method = SSLv23_method : SSL_METHOD
+  fun tlsv1_method = TLSv1_method : SSL_METHOD
+  fun tlsv1_1_method = TLSv1_1_method : SSL_METHOD
+  fun tlsv1_2_method = TLSv1_2_method : SSL_METHOD
+  fun dtlsv1_method = DTLSv1_method : SSL_METHOD
+  fun dtlsv1_2_method = DTLSv1_2_method : SSL_METHOD
 
   alias SSL_CTX = Void*
 
-  SSL_VERIFY_NONE = 0
-  SSL_VERIFY_PEER = 1
+  SSL_VERIFY_NONE                 = 0
+  SSL_VERIFY_PEER                 = 1
   SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 2
-  X509_FILETYPE_PEM = 1
-  X509_FILETYPE_ASN1 = 2
-  X509_FILETYPE_DEFAULT = 3
+  X509_FILETYPE_PEM               = 1
+  X509_FILETYPE_ASN1              = 2
+  X509_FILETYPE_DEFAULT           = 3
 
   alias VerifyCallback = (Int32, LibCrypto::X509_STORE_CTX) -> Int32
 
-  fun ssl_ctx_new = SSL_CTX_new(meth: SSL_METHOD) : SSL_CTX
-  fun ssl_ctx_free = SSL_CTX_free(ctx: SSL_CTX)
-  fun ssl_ctx_get_ex_new_index = SSL_CTX_get_ex_new_index(argl: Int64, argp: Void*, new_func: Void*,
-                                                          dup_func: Void*, free_func: Void*) : Int32
-  fun ssl_ctx_set_ex_data = SSL_CTX_set_ex_data(ctx: SSL_CTX, idx: Int32, arg: Void*) : Int32
-  fun ssl_ctx_set_verify = SSL_CTX_set_verify(ctx: SSL_CTX, mode: Int32, ct: VerifyCallback)
-  fun ssl_get_ex_data_x509_store_ctx_idx = SSL_get_ex_data_X509_STORE_CTX_idx() : Int32
-  fun x509_store_ctx_get_ex_data = X509_STORE_CTX_get_ex_data(ctx: LibCrypto::X509_STORE_CTX, idx: Int32) : Void*
-  fun ssl_get_ssl_ctx = SSL_get_SSL_CTX(ssl: Void*) : SSL_CTX
-  fun ssl_ctx_get_ex_data = SSL_CTX_get_ex_data(ctx: SSL_CTX, idx: Int32) : Void*
-  fun ssl_ctx_set_verify_depth = SSL_CTX_set_verify_depth(ctx: SSL_CTX, depth: Int32)
-  fun ssl_ctx_load_verify_locations = SSL_CTX_load_verify_locations(ctx: SSL_CTX, ca_file: UInt8*, ca_path: UInt8*) : Int32
-  fun ssl_ctx_use_certificate_file = SSL_CTX_use_certificate_file(ctx: SSL_CTX, file: UInt8*, type: Int32) : Int32
-  fun ssl_ctx_use_certificate = SSL_CTX_use_certificate(ctx: SSL_CTX, x509: LibCrypto::X509) : Int32
-  fun ssl_ctx_use_privatekey_file = SSL_CTX_use_PrivateKey_file(ctx: SSL_CTX, file: UInt8*, type: Int32) : Int32
-  fun ssl_ctx_use_privatekey = SSL_CTX_use_PrivateKey(ctx: SSL_CTX, pkey: LibCrypto::EVP_PKEY) : Int32
-  fun ssl_ctx_check_private_key = SSL_CTX_check_private_key(ctx: SSL_CTX) : Int32
-  fun ssl_ctx_set_cipher_list = SSL_CTX_set_cipher_list(ctx: SSL_CTX, str: UInt8*) : Int32
-  fun ssl_ctx_set_default_verify_paths = SSL_CTX_set_default_verify_paths(ctx: SSL_CTX) : Int32
-  fun ssl_ctx_use_certificate_chain_file = SSL_CTX_use_certificate_chain_file(ctx: SSL_CTX, file: UInt8*) : Int32
+  fun ssl_ctx_new = SSL_CTX_new(meth : SSL_METHOD) : SSL_CTX
+  fun ssl_ctx_free = SSL_CTX_free(ctx : SSL_CTX)
+  fun ssl_ctx_get_ex_new_index = CRYPTO_get_ex_new_index(class_index : Int32, argl : Int64, argp : Void*, new_func : Void*,
+                                                         dup_func : Void*, free_func : Void*) : Int32
+  fun ssl_ctx_set_ex_data = SSL_CTX_set_ex_data(ctx : SSL_CTX, idx : Int32, arg : Void*) : Int32
+  fun ssl_ctx_set_verify = SSL_CTX_set_verify(ctx : SSL_CTX, mode : Int32, ct : VerifyCallback)
+  fun ssl_get_ex_data_x509_store_ctx_idx = SSL_get_ex_data_X509_STORE_CTX_idx : Int32
+  fun x509_store_ctx_get_ex_data = X509_STORE_CTX_get_ex_data(ctx : LibCrypto::X509_STORE_CTX, idx : Int32) : Void*
+  fun ssl_get_ssl_ctx = SSL_get_SSL_CTX(ssl : Void*) : SSL_CTX
+  fun ssl_ctx_get_ex_data = SSL_CTX_get_ex_data(ctx : SSL_CTX, idx : Int32) : Void*
+  fun ssl_ctx_set_verify_depth = SSL_CTX_set_verify_depth(ctx : SSL_CTX, depth : Int32)
+  fun ssl_ctx_load_verify_locations = SSL_CTX_load_verify_locations(ctx : SSL_CTX, ca_file : UInt8*, ca_path : UInt8*) : Int32
+  fun ssl_ctx_use_certificate_file = SSL_CTX_use_certificate_file(ctx : SSL_CTX, file : UInt8*, type : Int32) : Int32
+  fun ssl_ctx_use_certificate = SSL_CTX_use_certificate(ctx : SSL_CTX, x509 : LibCrypto::X509) : Int32
+  fun ssl_ctx_use_privatekey_file = SSL_CTX_use_PrivateKey_file(ctx : SSL_CTX, file : UInt8*, type : Int32) : Int32
+  fun ssl_ctx_use_privatekey = SSL_CTX_use_PrivateKey(ctx : SSL_CTX, pkey : LibCrypto::EVP_PKEY) : Int32
+  fun ssl_ctx_check_private_key = SSL_CTX_check_private_key(ctx : SSL_CTX) : Int32
+  fun ssl_ctx_set_cipher_list = SSL_CTX_set_cipher_list(ctx : SSL_CTX, str : UInt8*) : Int32
+  fun ssl_ctx_set_default_verify_paths = SSL_CTX_set_default_verify_paths(ctx : SSL_CTX) : Int32
+  fun ssl_ctx_use_certificate_chain_file = SSL_CTX_use_certificate_chain_file(ctx : SSL_CTX, file : UInt8*) : Int32
 
-  SSL_CTRL_SET_READ_AHEAD = 41
+  SSL_CTRL_SET_READ_AHEAD   = 41
   SSL_CTRL_EXTRA_CHAIN_CERT = 14
-  SSL_CTRL_CLEAR_OPTIONS = 77
-  SSL_CTRL_OPTIONS = 32
-  fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx: SSL_CTX, cmd: Int32, larg: Int64, parg: Void*) : Int64
+  SSL_CTRL_CLEAR_OPTIONS    = 77
+  SSL_CTRL_OPTIONS          = 32
+  fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx : SSL_CTX, cmd : Int32, larg : Int64, parg : Void*) : Int64
 
   alias SSL = Void*
 
-  fun ssl_new = SSL_new(ctx: SSL_CTX) : SSL
-  fun ssl_free = SSL_free(ssl: SSL)
-  fun ssl_set_bio = SSL_set_bio(ssl: SSL, rbio: LibCrypto::BIO, wbio: LibCrypto::BIO)
-  fun ssl_connect = SSL_connect(ssl: SSL) : Int32
-  fun ssl_accept = SSL_accept(ssl: SSL) : Int32
-  fun ssl_read = SSL_read(ssl: SSL, buf: UInt8*, num: Int32) : Int32
-  fun ssl_write = SSL_write(ssl: SSL, buf: UInt8*, num: Int32) : Int32
-  fun ssl_shutdown = SSL_shutdown(ssl: SSL) : Int32
-  fun ssl_get_peer_certificate = SSL_get_peer_certificate(ssl: SSL) : LibCrypto::X509
-  fun ssl_renegotiate = SSL_renegotiate(ssl: SSL) : Int32
-  fun ssl_pending = SSL_pending(ssl: SSL) : Int32
-  fun ssl_do_handshake = SSL_do_handshake(ssl: SSL) : Int32
+  fun ssl_new = SSL_new(ctx : SSL_CTX) : SSL
+  fun ssl_free = SSL_free(ssl : SSL)
+  fun ssl_set_bio = SSL_set_bio(ssl : SSL, rbio : LibCrypto::BIO, wbio : LibCrypto::BIO)
+  fun ssl_connect = SSL_connect(ssl : SSL) : Int32
+  fun ssl_accept = SSL_accept(ssl : SSL) : Int32
+  fun ssl_read = SSL_read(ssl : SSL, buf : UInt8*, num : Int32) : Int32
+  fun ssl_write = SSL_write(ssl : SSL, buf : UInt8*, num : Int32) : Int32
+  fun ssl_shutdown = SSL_shutdown(ssl : SSL) : Int32
+  fun ssl_get_peer_certificate = SSL_get_peer_certificate(ssl : SSL) : LibCrypto::X509
+  fun ssl_renegotiate = SSL_renegotiate(ssl : SSL) : Int32
+  fun ssl_pending = SSL_pending(ssl : SSL) : Int32
+  fun ssl_do_handshake = SSL_do_handshake(ssl : SSL) : Int32
 
-  SSL_ERROR_NONE = 0
-  SSL_ERROR_SSL = 1
-  SSL_ERROR_SYSCALL = 5
-  SSL_ERROR_WANT_ACCEPT = 8
-  SSL_ERROR_WANT_CONNECT = 7
-  SSL_ERROR_WANT_READ = 2
-  SSL_ERROR_WANT_WRITE = 3
+  SSL_ERROR_NONE             = 0
+  SSL_ERROR_SSL              = 1
+  SSL_ERROR_SYSCALL          = 5
+  SSL_ERROR_WANT_ACCEPT      = 8
+  SSL_ERROR_WANT_CONNECT     = 7
+  SSL_ERROR_WANT_READ        = 2
+  SSL_ERROR_WANT_WRITE       = 3
   SSL_ERROR_WANT_X509_LOOKUP = 4
-  SSL_ERROR_ZERO_RETURN = 6
+  SSL_ERROR_ZERO_RETURN      = 6
 
-  fun ssl_get_error = SSL_get_error(ssl: SSL, ret: Int32) : Int32
+  fun ssl_get_error = SSL_get_error(ssl : SSL, ret : Int32) : Int32
 end

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -6,18 +6,16 @@ module OpenSSL
     getter err_msg
 
     def initialize(msg = nil)
+      @err_msg = ""
+
       unless (err = @err = LibCrypto.get_error) == 0
         @err_msg = String.new(LibCrypto.err_error_string(err, nil))
-        msg = msg ? "#{msg}: #{@err_msg}": @err_msg
+        msg = msg ? "#{msg}: #{@err_msg}" : @err_msg
       end
+
       super(msg)
     end
   end
-
-  LibSSL.ssl_library_init()
-  LibSSL.openssl_add_all_algorithms()
-  LibSSL.err_load_crypto_strings()
-  LibSSL.ssl_load_error_strings()
 end
 
 require "./digest/*"

--- a/src/pkey/dsa.cr
+++ b/src/pkey/dsa.cr
@@ -6,7 +6,7 @@ module OpenSSL
     class DSAError < PKeyError; end
 
     def self.new(pem : String, password = nil)
-      self.new(MemoryIO.new(pem), password)
+      self.new(IO::Memory.new(pem), password)
     end
 
     def self.new(io : IO, password = nil)
@@ -28,7 +28,7 @@ module OpenSSL
         raise DSAError.new "Neither PUB or PRIV key"
       end
       new(priv_key).tap do |pkey|
-        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_dsa, dsa as Pointer(Void))
+        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_dsa, dsa.as(Pointer(Void)))
       end
     end
 
@@ -46,7 +46,7 @@ module OpenSSL
         raise DSAError.new
       end
       new(true).tap do |pkey|
-        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_dsa, dsa as Pointer(Void))
+        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_dsa, dsa.as(Pointer(Void)))
       end
     end
 
@@ -67,7 +67,7 @@ module OpenSSL
     end
 
     def to_der
-      fn = ->(buf: UInt8**|Nil) {
+      fn = ->(buf : UInt8** | Nil) {
         if private_key?
           LibCrypto.i2d_dsaprivatekey(dsa, buf)
         else
@@ -87,9 +87,9 @@ module OpenSSL
     def public_key
       f1 = ->LibCrypto.i2d_dsapublickey
       f2 = ->LibCrypto.d2i_dsapublickey
-      pub_dsa = LibCrypto.asn1_dup(f1.pointer, f2.pointer, dsa as Void*) as DSA
+      pub_dsa = LibCrypto.asn1_dup(f1.pointer, f2.pointer, dsa.as(Void*)).as(DSA)
       DSA.new(false).tap do |pkey|
-        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_dsa, pub_dsa as Pointer(Void))
+        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_dsa, pub_dsa.as(Pointer(Void)))
       end
     end
 

--- a/src/pkey/pkey.cr
+++ b/src/pkey/pkey.cr
@@ -9,7 +9,7 @@ module OpenSSL
     end
 
     def initialize(is_private)
-      initialize(LibCrypto.evp_pkey_new(), is_private)
+      initialize(LibCrypto.evp_pkey_new, is_private)
     end
 
     def to_unsafe
@@ -59,7 +59,7 @@ module OpenSSL
     end
 
     def to_pem
-      io = MemoryIO.new
+      io = IO::Memory.new
       to_pem(io)
       io.to_s
     end

--- a/src/pkey/rsa.cr
+++ b/src/pkey/rsa.cr
@@ -5,7 +5,7 @@ module OpenSSL
     class RSAError < PKeyError; end
 
     def self.new(pem : String, password = nil)
-      self.new(MemoryIO.new(io), password)
+      self.new(IO::Memory.new(io), password)
     end
 
     def self.new(io : IO, password = nil)
@@ -22,14 +22,14 @@ module OpenSSL
     def self.generate(size)
       rsa = LibCrypto.rsa_generate_key(size, 65537.to_u32, nil, nil)
       new(true).tap do |pkey|
-        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_rsaEncryption, rsa as Pointer(Void))
+        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_rsaEncryption, rsa.as(Pointer(Void)))
       end
     end
 
     def public_key
       pub_rsa = LibCrypto.rsapublickey_dup(rsa)
       RSA.new(false).tap do |pkey|
-        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_rsaEncryption, pub_rsa as Pointer(Void))
+        LibCrypto.evp_pkey_assign(pkey, LibCrypto::NID_rsaEncryption, pub_rsa.as(Pointer(Void)))
       end
     end
 
@@ -107,7 +107,7 @@ module OpenSSL
     end
 
     def to_der
-      fn = ->(buf: UInt8**|Nil) {
+      fn = ->(buf : UInt8** | Nil) {
         if private_key?
           LibCrypto.i2d_rsaprivatekey(rsa, buf)
         else

--- a/src/ssl/context.cr
+++ b/src/ssl/context.cr
@@ -3,14 +3,14 @@ module OpenSSL::SSL
 
   @[Flags]
   enum VerifyMode
-    PEER = LibSSL::SSL_VERIFY_PEER
-    NONE = LibSSL::SSL_VERIFY_NONE
+    PEER                 = LibSSL::SSL_VERIFY_PEER
+    NONE                 = LibSSL::SSL_VERIFY_NONE
     FAIL_IF_NO_PEER_CERT = LibSSL::SSL_VERIFY_FAIL_IF_NO_PEER_CERT
   end
 
   enum FileType
-    PEM = LibSSL::X509_FILETYPE_PEM
-    ASN1 = LibSSL::X509_FILETYPE_ASN1
+    PEM     = LibSSL::X509_FILETYPE_PEM
+    ASN1    = LibSSL::X509_FILETYPE_ASN1
     DEFAULT = LibSSL::X509_FILETYPE_DEFAULT
   end
 
@@ -49,15 +49,16 @@ module OpenSSL::SSL
   class Context
     alias VerifyCallback = (Bool, X509::StoreContext) -> Bool
 
+    @@index : Int32
     @@index = begin
-                index = LibSSL.ssl_ctx_get_ex_new_index(0_i64, nil, nil, nil, nil)
-                if index < 0
-                  raise SSLError.new "invalid index"
-                end
-                index
-              end
+      index = LibSSL.ssl_ctx_get_ex_new_index(0, 0_i64, nil, nil, nil, nil)
+      if index < 0
+        raise SSLError.new "invalid index"
+      end
+      index
+    end
 
-    def initialize(@handle : LibSSL::SSL_CTX) 
+    def initialize(@handle : LibSSL::SSL_CTX)
       raise SSLError.new "invalid handle" unless @handle
     end
 
@@ -78,7 +79,7 @@ module OpenSSL::SSL
     end
 
     protected def self.raw_verify(preverify_ok : Int32, ctx : LibCrypto::X509_STORE_CTX)
-      idx = LibSSL.ssl_get_ex_data_x509_store_ctx_idx()
+      idx = LibSSL.ssl_get_ex_data_x509_store_ctx_idx
       ssl = LibSSL.x509_store_ctx_get_ex_data(ctx, idx)
       ssl_ctx = LibSSL.ssl_get_ssl_ctx(ssl)
       verify = LibSSL.ssl_ctx_get_ex_data(ssl_ctx, @@index)

--- a/src/ssl/method.cr
+++ b/src/ssl/method.cr
@@ -13,19 +13,19 @@ enum OpenSSL::SSL::Method
     # when SSLv2
     #   LibSSL.sslv2_method()
     when SSLv23
-      LibSSL.sslv23_method()
+      LibSSL.sslv23_method
     when SSLv3
-      LibSSL.sslv3_method()
+      LibSSL.sslv3_method
     when TLSv1
-      LibSSL.tlsv1_method()
+      LibSSL.tlsv1_method
     when TLSv1_1
-      LibSSL.tlsv1_1_method()
+      LibSSL.tlsv1_1_method
     when TLSv1_2
-      LibSSL.tlsv1_2_method()
+      LibSSL.tlsv1_2_method
     when DTLSv1
-      LibSSL.dtlsv1_method()
+      LibSSL.dtlsv1_method
     when DTLSv1_2
-      LibSSL.dtlsv1_2_method()
+      LibSSL.dtlsv1_2_method
     end
   end
 end

--- a/src/ssl/socket.cr
+++ b/src/ssl/socket.cr
@@ -1,8 +1,6 @@
 require "../openssl"
 
 class OpenSSL::SSL::Socket
-  include IO
-
   def initialize(io, @context : Context)
     @handle = LibSSL.ssl_new(@context)
     raise SSLError.new "invalid handle" unless @handle

--- a/src/x509/certificate.cr
+++ b/src/x509/certificate.cr
@@ -16,7 +16,7 @@ module OpenSSL::X509
       raise X509Error.new "invalid handle" unless @handle
     end
 
-    def name(flag = Flags::COMPAT : Flags)
+    def name(flag : Flags = Flags::COMPAT)
       bio = MemBIO.new
       if LibCrypto.x509_name_print_ex(bio, self, 0, flag.value.to_u64) == 0
         raise X509Error.new
@@ -74,7 +74,7 @@ module OpenSSL::X509
       Name.new LibCrypto.x509_name_dup(handle)
     end
 
-    def fingerprint(digest = OpenSSL::Digest::SHA1.new : OpenSSL::Digest)
+    def fingerprint(digest : OpenSSL::Digest = OpenSSL::Digest::SHA1.new)
       slice = Slice(UInt8).new digest.digest_size
       if LibCrypto.x509_digest(self, digest.to_unsafe_md, slice, out len) == 0
         raise X509Error.new
@@ -85,7 +85,7 @@ module OpenSSL::X509
       slice
     end
 
-    def fingerprint_hex(digest = OpenSSL::Digest::SHA1.new : OpenSSL::Digest)
+    def fingerprint_hex(digest : OpenSSL::Digest = OpenSSL::Digest::SHA1.new)
       DigestBase.hexdump(fingerprint(digest))
     end
 
@@ -104,7 +104,7 @@ module OpenSSL::X509
     end
 
     def to_pem
-      io = MemoryIO.new
+      io = IO::Memory.new
       to_pem(io)
       io.to_s
     end

--- a/src/x509/generator.cr
+++ b/src/x509/generator.cr
@@ -71,11 +71,11 @@ class OpenSSL::X509::Generator
     LibCrypto.x509_set_issuer_name(certificate, name)
 
     unless usage.empty?
-      value = usage.map{|v| v.to_s.gsub(/^\w/){|s| s[0].downcase}}.join(",")
+      value = usage.map { |v| v.to_s.gsub(/^\w/) { |s| s[0].downcase } }.join(",")
       add_extension(certificate, LibCrypto::NID_key_usage, value)
     end
     unless ext_usage.empty?
-      value = ext_usage.map{|v| v.to_s.gsub(/^\w/){|s| s[0].downcase}}.join(",")
+      value = ext_usage.map { |v| v.to_s.gsub(/^\w/) { |s| s[0].downcase } }.join(",")
       add_extension(certificate, LibCrypto::NID_ext_key_usage, value)
     end
     if LibCrypto.x509_sign(certificate, pkey, digest.new.to_unsafe_md) == 0
@@ -99,9 +99,9 @@ class OpenSSL::X509::Generator
 
   private def random_serial
     long = uninitialized Int64
-    ptr = pointerof(long) as Int32*
-    ptr[0] = rand(UInt32::MAX)
-    ptr[1] = rand(UInt32::MAX)
+    ptr = pointerof(long).as(Int32*)
+    ptr[0] = rand(Int32::MAX)
+    ptr[1] = rand(Int32::MAX)
     long
   end
 end


### PR DESCRIPTION
Ran `crystal tool format` and moved a couple things around. Mostly cosmetic changes, `a :: Int32` to `a = uninitialized Int32`, `MemoryIO` to `IO::Memory`, etc. The only spec that doesn't pass yet is HMAC, which is already in the standard library anyway. Keep in mind these are the *minimum* changes required for the specs to pass, I'm sure there's other things in there that should look nicer with Crystal 0.26.

This project hasn't seen much attention recently, but I'd be interested to know if RSA is planned for the stdlib?